### PR TITLE
Force Signing Build Settings updates

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,10 +117,6 @@ func (configs ConfigsModel) print() {
 	}
 
 	log.Printf("- UseDeprecatedExport: %s", configs.UseDeprecatedExport)
-	log.Printf("- ForceTeamID: %s", configs.ForceTeamID)
-	log.Printf("- ForceProvisioningProfileSpecifier: %s", configs.ForceProvisioningProfileSpecifier)
-	log.Printf("- ForceProvisioningProfile: %s", configs.ForceProvisioningProfile)
-	log.Printf("- ForceCodeSignIdentity: %s", configs.ForceCodeSignIdentity)
 	log.Printf("- CustomExportOptionsPlistContent:")
 	if configs.CustomExportOptionsPlistContent != "" {
 		log.Printf(configs.CustomExportOptionsPlistContent)
@@ -136,6 +132,10 @@ func (configs ConfigsModel) print() {
 	log.Printf("- OutputDir: %s", configs.OutputDir)
 	log.Printf("- IsCleanBuild: %s", configs.IsCleanBuild)
 	log.Printf("- XcodebuildOptions: %s", configs.XcodebuildOptions)
+	log.Printf("- ForceTeamID: %s", configs.ForceTeamID)
+	log.Printf("- ForceProvisioningProfileSpecifier: %s", configs.ForceProvisioningProfileSpecifier)
+	log.Printf("- ForceProvisioningProfile: %s", configs.ForceProvisioningProfile)
+	log.Printf("- ForceCodeSignIdentity: %s", configs.ForceCodeSignIdentity)
 	fmt.Println()
 
 	log.Infof("step output configs:")

--- a/step.yml
+++ b/step.yml
@@ -132,24 +132,24 @@ inputs:
         specified by the Scheme and will silently ignore this parameter!
   - force_team_id:
     opts:
-      category: Force Code Signing Options (deprecated)
-      title: "Force Developer Portal team to use during archive"
+      category: Force Signing Build Settings
+      title: "Force code signing with Development Team"
       description: |-
         Used for Xcode version 8 and above.
 
-        Force xcodebuild to use specified Developer Portal team during archive.
+        Force xcodebuild to use specified Development Team (DEVELOPMENT_TEAM).
 
         Format example:
 
         - `1MZX23ABCD4`
   - force_code_sign_identity:
     opts:
-      category: Force Code Signing Options (deprecated)
-      title: "Force code signing with Identity"
+      category: Force Signing Build Settings
+      title: "Force code signing with Code Signing Identity"
       description: |-
-        Force xcodebuild to use specified Code Sign Identity.
+        Force xcodebuild to use specified Code Signing Identity (CODE_SIGN_IDENTITY).
 
-        Specify code sign identity as full ID (e.g. `iPhone Developer: Bitrise Bot (VV2J4SV8V4)`)
+        Specify Code Signing Identity as full ID (e.g. `iPhone Developer: Bitrise Bot (VV2J4SV8V4)`)
         or specify code sign group ( `iPhone Developer` or `iPhone Distribution` ).
 
         You also have to **specify the Identity in the format it's stored in Xcode project settings**,
@@ -159,12 +159,12 @@ inputs:
         **Capitalization also matters**, `iPhone Distribution` works but `iphone distribution` does not!
   - force_provisioning_profile_specifier:
     opts:
-      category: Force Code Signing Options (deprecated)
+      category: Force Signing Build Settings
       title: "Force code signing with Provisioning Profile Specifier"
       description: |-
         Used for Xcode version 8 and above.
 
-        Force xcodebuild to use specified Provisioning Profile.
+        Force xcodebuild to use specified Provisioning Profile (PROVISIONING_PROFILE_SPECIFIER).
 
         How to get your Provisioning Profile Specifier:
 
@@ -177,10 +177,10 @@ inputs:
         - `1MZX23ABCD4/My Provisioning Profile`
   - force_provisioning_profile:
     opts:
-      category: Force Code Signing Options (deprecated)
+      category: Force Signing Build Settings
       title: "Force code signing with Provisioning Profile"
       description: |-
-        Force xcodebuild to use specified Provisioning Profile.
+        Force xcodebuild to use specified Provisioning Profile (PROVISIONING_PROFILE).
 
         Use Provisioning Profile's UUID, profile's name is not acceptable by xcodebuild.
 


### PR DESCRIPTION
`force_team_id`, `force_code_sign_identity`, `force_provisioning_profile_specifier` and `force_provisioning_profile` are not deprecated options, in some cases they are required!

If you manually change the Code Signing Style from Automatic to Manual (XcodebuildOptions: CODE_SIGN_STYLE="Manual"), team, prov profile and code sign identity will be set to 'none', in this case you have to use the mentioned inputs to specify code singing for the __archive__ process and these are not ipa export configs! 