### PR TITLE
Fix archiving for Xcode9

### DIFF
--- a/main.go
+++ b/main.go
@@ -587,7 +587,7 @@ is available in the $BITRISE_XCODE_RAW_RESULT_TEXT_PATH environment variable`)
 
 						profileName = embeddedProfileName
 					} else {
-						profileName := codeSignInfo.ProvisioningProfileSpecifier
+						profileName = codeSignInfo.ProvisioningProfileSpecifier
 						if profileName != "" {
 							log.Printf("using project specified profile specifier (%s) to sign: %s", profileName, codeSignInfo.BundleIdentifier)
 						} else if codeSignInfo.ProvisioningProfile != "" {


### PR DESCRIPTION
I might found a bug when I tried to archive for Xcode9.
It seems profileName variable is hiding by inner same named variable.

I checked my this branch works well.

Would you check this?